### PR TITLE
Fix glazed terracotta being 'upside down'

### DIFF
--- a/src/generated/resources/assets/dye_depot/blockstates/amber_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/amber_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/amber_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/amber_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/amber_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/amber_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/amber_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/aqua_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/aqua_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/aqua_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/aqua_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/aqua_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/aqua_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/aqua_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/beige_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/beige_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/beige_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/beige_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/beige_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/beige_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/beige_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/coral_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/coral_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/coral_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/coral_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/coral_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/coral_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/coral_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/forest_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/forest_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/forest_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/forest_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/forest_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/forest_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/forest_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/ginger_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/ginger_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/ginger_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/ginger_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/ginger_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/ginger_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/ginger_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/indigo_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/indigo_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/indigo_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/indigo_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/indigo_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/indigo_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/indigo_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/maroon_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/maroon_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/maroon_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/maroon_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/maroon_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/maroon_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/maroon_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/mint_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/mint_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/mint_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/mint_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/mint_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/mint_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/mint_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/navy_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/navy_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/navy_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/navy_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/navy_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/navy_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/navy_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/olive_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/olive_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/olive_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/olive_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/olive_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/olive_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/olive_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/rose_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/rose_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/rose_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/rose_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/rose_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/rose_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/rose_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/slate_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/slate_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/slate_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/slate_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/slate_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/slate_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/slate_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/tan_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/tan_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/tan_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/tan_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/tan_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/tan_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/tan_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/teal_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/teal_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/teal_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/teal_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/teal_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/teal_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/teal_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/generated/resources/assets/dye_depot/blockstates/verdant_glazed_terracotta.json
+++ b/src/generated/resources/assets/dye_depot/blockstates/verdant_glazed_terracotta.json
@@ -2,18 +2,18 @@
   "variants": {
     "facing=east": {
       "model": "dye_depot:block/verdant_glazed_terracotta",
-      "y": 90
+      "y": 270
     },
     "facing=north": {
-      "model": "dye_depot:block/verdant_glazed_terracotta"
-    },
-    "facing=south": {
       "model": "dye_depot:block/verdant_glazed_terracotta",
       "y": 180
     },
+    "facing=south": {
+      "model": "dye_depot:block/verdant_glazed_terracotta"
+    },
     "facing=west": {
       "model": "dye_depot:block/verdant_glazed_terracotta",
-      "y": 270
+      "y": 90
     }
   }
 }

--- a/src/main/java/com/ninni/dye_depot/data/client/DDBlockModels.java
+++ b/src/main/java/com/ninni/dye_depot/data/client/DDBlockModels.java
@@ -67,7 +67,7 @@ public class DDBlockModels extends BlockStateProvider {
     private void glazedTerracotta(Holder<? extends Block> block) {
         var model = models().withExistingParent(name(block), vanillaResource("template_glazed_terracotta"))
                 .texture("pattern", blockTexture(block));
-        horizontalBlock(block.value(), model);
+        horizontalBlock(block.value(), model, 0);
     }
 
     private void stainedGlassPane(DyeColor color, Holder<? extends StainedGlassPaneBlock> block) {


### PR DESCRIPTION
If you look at glazed terracotta's blockstate definition in vanilla, it is rotated by 180 degrees compared to this mod's blockstates. I have rectified this with a single line change.

This is important because when making mods that interface with this mod, textures can seem to be upside down for reasons that are not immediately apparent (I discovered this when making my mod, Saturated Sands, compatible with this mod). It also is an issue for simple texture packs, if they have to invert the texture or edit the model where it otherwise would not have been needed.